### PR TITLE
Add JET_MEMBER_ADDRESS property

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN cd mvnw \
 ENV CLASSPATH_DEFAULT "${MC_RUNTIME}"
 ENV LOADER_PATH "${MC_HOME}/lib"
 ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true -Dloader.path=${LOADER_PATH}"
+ENV MC_INSTALL_DIR "$MC_INSTALL_DIR"
 
 ENV MIN_HEAP_SIZE ""
 ENV MAX_HEAP_SIZE ""
@@ -72,10 +73,11 @@ ENV CLASSPATH ""
 ENV CLI_ARGS ""
 ENV MC_HTTP_PORT 8081
 ENV MC_LICENSE_KEY ""
-ENV MC_CLIENT_CONFIG ""
+ENV MC_CLIENT_CONFIG "${MC_INSTALL_DIR}/hazelcast-client.xml"
 ENV MC_APPLICATION_CONFIG ""
 ENV MC_USER ""
 ENV MC_PASSWORD ""
+ENV JET_MEMBER_ADDRESS ""
 
 EXPOSE ${MC_HTTP_PORT}
 
@@ -91,6 +93,7 @@ CMD ["bash", "-c", "set -euo pipefail \
       && if [[ \"x${MC_APPLICATION_CONFIG}\" != \"x\" ]]; then export CLI_ARGS=\"${CLI_ARGS} -f ${MC_APPLICATION_CONFIG}\"; fi \
       && if [[ \"x${MC_USER}\" != \"x\" ]]; then export CLI_ARGS=\"${CLI_ARGS} -U ${MC_USER}\"; fi \
       && if [[ \"x${MC_PASSWORD}\" != \"x\" ]]; then export CLI_ARGS=\"${CLI_ARGS} -P ${MC_PASSWORD}\"; fi \
+      && if [[ \"x${JET_MEMBER_ADDRESS}\" != \"x\" ]]; then sed -i \"s/127.0.0.1/${JET_MEMBER_ADDRESS}/g;\" ${MC_INSTALL_DIR}/hazelcast-client.xml; fi \
       && echo \"########################################\" \
       && echo \"# JAVA_OPTS=${JAVA_OPTS}\" \
       && echo \"# CLASSPATH=${CLASSPATH}\" \


### PR DESCRIPTION
MC defaults to 127.0.0.1, this is not suitable for Docker environment.
This allows to configure Jet address via env variable without having to
provide custom configuration file (does in place replacement in the
default hazelcast-client.xml).

Anything more sophisticated should go to unified MC.